### PR TITLE
Swapped the values in attributeValues to give additional control

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -216,7 +216,7 @@ function attributeValue(ctx, key, value, info) {
       // Always encode without parse errors in non-HTML.
       subset = subset[space === 'html' ? ctx.valid : 1][ctx.safe]
 
-      value = entities(value, xtend(options, {subset: subset, attribute: true}))
+      value = entities(value, xtend({subset: subset, attribute: true}, options))
 
       value = quote + value + quote
     }


### PR DESCRIPTION
fixes #11 

Hi, @wooorm and the team a big thanks ❤️ for the amazing tool and the hard work. Here is a small feature request that I would like to make with this pull request and I am going to explain why I was requesting for this.

## Current Behaviour :
``& and "`` are being escaped by default.

Currently, we can control the ``allowDangerousCharacters`` and ``allowDangerousHTML`` at the time of configuration which toggles the builder to ``ctx.safe = 0``. 

I observed that ``& and '`` are still escaped by default through the ``subset`` that is being passed to the ``stringify-entities `` for stringifying the ``attributeNames`` but we got a bit of situation here when we are implementing it [here](https://github.com/teleporthq/teleport-code-generators/issues/96) our ``& and ''`` are being escaped which we don't want to happen.

This behavior is because of the ``subset`` which is being passed to the ``stringify-entities`` is not picking up the configuration that is being passed to ``hast-util-to-html``

## Proposed Behaviour
By swapping the options to the end, it gives the user to control the behavior of the subset that they don't want to escape while configuring the ``hast-util-to-html`` 

Current Behaviour
``<span v-if="(state >= 3) &#x26;&#x26; (state < 5)">This is the fourth tab</span>``

can be changed to output to this
``<span v-if="(state >= 3) && (state < 5)">This is the fourth tab</span>``

by making the configuration to this

### Control in configuration

`toHTML(tree, { entities: { subset: []}})`
