### PR TITLE
Don’t omit </p> before <table>

### DIFF
--- a/lib/omission/closing.js
+++ b/lib/omission/closing.js
@@ -98,7 +98,6 @@ function p(_, index, parent) {
         'p',
         'pre',
         'section',
-        'table',
         'ul'
       ])
     : !parent ||

--- a/test/omission-closing-p.js
+++ b/test/omission-closing-p.js
@@ -64,5 +64,11 @@ test('`p` (closing)', (t) => {
     'should not omit tag if parented by `section`'
   )
 
+  t.deepEqual(
+    toHtml(h('body', [h('p'), h('table')]), {omitOptionalTags: true}),
+    '<p></p><table></table>',
+    'should not omit tag if followed by `table`'
+  )
+
   t.end()
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

On a website in the wild, I found that the DOM structure `<p></p><table></table>` is minified by `rehype-minify` into `<p><table></table>`. However, both Safari and Chrome interpret this as `<p><table></table></p>`. Therefore, I’ve added a test and updated the code to insert the `</p>` in this case.

<!--do not edit: pr-->
