### PR TITLE
Refactor to improve performance w/ hoisted regex

### DIFF
--- a/lib/handle/comment.js
+++ b/lib/handle/comment.js
@@ -7,6 +7,12 @@
 
 import {stringifyEntities} from 'stringify-entities'
 
+const htmlCommentRegex = /^>|^->|<!--|-->|--!>|<!-$/g
+
+// Declare arrays as variables so it can be cached by `stringifyEntities`
+const bogusCommentEntitySubset = ['>']
+const commentEntitySubset = ['<', '>']
+
 /**
  * Serialize a comment.
  *
@@ -27,10 +33,12 @@ export function comment(node, _1, _2, state) {
     ? '<?' +
         stringifyEntities(
           node.value,
-          Object.assign({}, state.settings.characterReferences, {subset: ['>']})
+          Object.assign({}, state.settings.characterReferences, {
+            subset: bogusCommentEntitySubset
+          })
         ) +
         '>'
-    : '<!--' + node.value.replace(/^>|^->|<!--|-->|--!>|<!-$/g, encode) + '-->'
+    : '<!--' + node.value.replace(htmlCommentRegex, encode) + '-->'
 
   /**
    * @param {string} $0
@@ -39,7 +47,7 @@ export function comment(node, _1, _2, state) {
     return stringifyEntities(
       $0,
       Object.assign({}, state.settings.characterReferences, {
-        subset: ['<', '>']
+        subset: commentEntitySubset
       })
     )
   }

--- a/lib/handle/text.js
+++ b/lib/handle/text.js
@@ -9,6 +9,9 @@
 
 import {stringifyEntities} from 'stringify-entities'
 
+// Declare array as variable so it can be cached by `stringifyEntities`
+const textEntitySubset = ['<', '&']
+
 /**
  * Serialize a text node.
  *
@@ -32,7 +35,7 @@ export function text(node, _, parent, state) {
     : stringifyEntities(
         node.value,
         Object.assign({}, state.settings.characterReferences, {
-          subset: ['<', '&']
+          subset: textEntitySubset
         })
       )
 }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Following https://github.com/wooorm/stringify-entities/pull/13, in this PR I made changes so that the `subset` passed to `stringifyEntities()` is a variable so it can be cached via a WeakMap.

I also hoisted a regex in `comment.js`. Didn't want to side-track the PR again, but it was only one instance 😬 

At https://github.com/wooorm/stringify-entities/pull/13, I mentioned that it helped brought the execution time of `toHtml` to 2.38s. With this PR, I measured it to drop to `1.99s`. Not as much as I expected, but perhaps every bit helps.

<!--do not edit: pr-->