### PR TITLE
add failing test case for allowParseErrors

### DIFF
--- a/test/security.js
+++ b/test/security.js
@@ -32,6 +32,18 @@ test('security', async function (t) {
     }
   )
 
+  await t.test(
+    'should make sure href attributes render (unsafe)',
+    async function () {
+      assert.equal(
+        toHtml(h('a', {href: 'https://a?b&c'}), {
+          allowParseErrors: true,
+        }),
+        '<a href="https://a?b&c">',
+      )
+    }
+  )
+
   await t.test('should make sure texts are encoded (safe)', async function () {
     assert.equal(
       toHtml(u('root', u('text', '<script>alert(1)</script>'))),


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
https://github.com/orgs/syntax-tree/discussions/114
*   [x] If applicable, I’ve added docs and tests

### Description of changes

currently added a failing test for `allowParseErrors` 

getting 

```
     error: |-
        Expected values to be strictly equal:
        + actual - expected

        + '<a href="https://a?b&#x26;c"></a>'
        - '<a href="https://a?b&c">'
```

<!--do not edit: pr-->
