### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@types/unist": "^3.0.0",
     "ccount": "^2.0.0",
     "comma-separated-tokens": "^2.0.0",
-    "hast-util-raw": "^9.0.0",
     "hast-util-whitespace": "^3.0.0",
     "html-void-elements": "^3.0.0",
     "mdast-util-to-hast": "^13.0.0",

--- a/test/raw.js
+++ b/test/raw.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('hast-util-raw')} DoNotTouchThisRegistersRawInTheTree
+ * @typedef {import('mdast-util-to-hast')} DoNotTouchThisRegistersRawInTheTree
  */
 
 import assert from 'node:assert/strict'


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Remove `hast-util-raw` as it's not used in the published files. It's only used in `test/raw.js` for ambient types, but I found from https://github.com/syntax-tree/hast-util-raw?tab=readme-ov-file#types and https://github.com/syntax-tree/mdast-util-to-hast?tab=readme-ov-file#types that the types should be sourced from `mdast-util-to-hast`, so I switched to that instead and `hast-util-raw` is no longer used anywhere else.

<!--do not edit: pr-->
