### PR TITLE
exempt strings from being treated as known booleans unless empty or equal to name

### DIFF
--- a/lib/handle/element.js
+++ b/lib/handle/element.js
@@ -173,8 +173,8 @@ function serializeAttribute(state, key, value) {
   if (info.overloadedBoolean && (value === info.attribute || value === '')) {
     value = true
   } else if (
-    info.boolean ||
-    (info.overloadedBoolean && typeof value !== 'string')
+    (typeof value !== 'string' || value === '' || value === info.attribute) &&
+    (info.boolean || info.overloadedBoolean)
   ) {
     value = Boolean(value)
   }

--- a/test/attribute.js
+++ b/test/attribute.js
@@ -140,6 +140,7 @@ test('`element` attributes', async (t) => {
       }
     )
 
+    // TODO: why? "hidden" is  a valid value for the `hidden` attribute
     await t.test(
       'should serialize known booleans set to their name without value',
       async function () {
@@ -158,6 +159,49 @@ test('`element` attributes', async (t) => {
         assert.deepEqual(
           toHtml(u('element', {tagName: 'i', properties: {hidden: 1}}, [])),
           '<i hidden></i>'
+        )
+      }
+    )
+
+    await t.test(
+      'should serialize known booleans set to arbitrary strings with value',
+      async function () {
+        assert.deepEqual(
+          toHtml(
+            h('div', {
+              selected: 'some string value for a well known boolean attribute'
+            })
+          ),
+          '<div selected="some string value for a well known boolean attribute"></div>'
+        )
+      }
+    )
+
+    await t.test(
+      'should serialize known booleans set to an empty string without value',
+      async function () {
+        assert.deepEqual(
+          toHtml(
+            h('div', {
+              selected: ''
+            })
+          ),
+          '<div selected></div>'
+        )
+      }
+    )
+
+    await t.test(
+      'should serialize known overloaded booleans set to arbitrary strings with value',
+      async function () {
+        assert.deepEqual(
+          toHtml(
+            h('div', {
+              download:
+                'some string value for a well known overloaded boolean attribute'
+            })
+          ),
+          '<div download="some string value for a well known overloaded boolean attribute"></div>'
         )
       }
     )

--- a/test/attribute.js
+++ b/test/attribute.js
@@ -140,7 +140,6 @@ test('`element` attributes', async (t) => {
       }
     )
 
-    // TODO: why? "hidden" is  a valid value for the `hidden` attribute
     await t.test(
       'should serialize known booleans set to their name without value',
       async function () {


### PR DESCRIPTION


<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This change prevents treating string attributes whose name is a well known boolean (or overloaded boolean) as a boolean if their values are 
- not empty
- not equal to their attributes name 

This is done to enable e.g. custom element to re-use those well known names with values that differ from their well known counterparts.

closes #45 

<!--do not edit: pr-->
